### PR TITLE
Add height to tables that have horizontal scrollbars

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mui-virtualized-table",
-  "version": "3.0.0-2",
+  "version": "3.0.0-3",
   "description": "Material-UI table with windowing, row/column freezing, and more",
   "main": "dist/index.js",
   "types": "index.d.ts",

--- a/src/index.js
+++ b/src/index.js
@@ -426,8 +426,6 @@ class MuiTable extends Component {
       ...props
     } = this.props;
 
-    const { scrollbar } = this.state;
-
     let calculatedHeight = 0;
     if (height) {
       calculatedHeight = height; // fixed height

--- a/src/index.js
+++ b/src/index.js
@@ -426,6 +426,8 @@ class MuiTable extends Component {
       ...props
     } = this.props;
 
+    const { scrollbar } = this.state;
+
     let calculatedHeight = 0;
     if (height) {
       calculatedHeight = height; // fixed height
@@ -443,8 +445,10 @@ class MuiTable extends Component {
     const paginationHeight =
       theme.mixins.toolbar.minHeight + FOOTER_BORDER_HEIGHT;
 
+    const scrollbarHeight = scrollbar.horizontal ? scrollbar.size : 0;
+
     const calculatedHeightWithFooter =
-      calculatedHeight + (pagination ? paginationHeight : 0);
+      calculatedHeight + (pagination ? paginationHeight : 0) + scrollbarHeight;
     const containerHeight =
       maxHeight != null
         ? Math.min(calculatedHeightWithFooter, maxHeight)

--- a/src/index.js
+++ b/src/index.js
@@ -162,6 +162,7 @@ class MuiTable extends Component {
     this.state = {
       hoveredColumn: null,
       hoveredRowData: null,
+      scrollbar: {},
       widths
     };
   }
@@ -379,6 +380,21 @@ class MuiTable extends Component {
     }
   }
 
+  captureScrollbarSize = (scrollbar) => {
+    this.setState({ scrollbar }, () => this.multiGrid.recomputeGridSize());
+  }
+
+  calculateColumnWidths = (col) => {
+    const { columns } = this.props;
+    const { scrollbar } = this.state;
+    const scrollbarWidth = scrollbar.vertical ? scrollbar.size : 0;
+    const offset = Array.isArray(columns) && columns.length > 0 
+      ? scrollbarWidth / columns.length
+      : 0;
+
+    return this.getColumnWidthFunction()(col) - offset;
+  }
+
   render() {
     const {
       data,
@@ -409,6 +425,8 @@ class MuiTable extends Component {
       resizable,
       ...props
     } = this.props;
+
+    const { scrollbar } = this.state;
 
     let calculatedHeight = 0;
     if (height) {
@@ -447,7 +465,7 @@ class MuiTable extends Component {
           cellRenderer={this.cellRenderer}
           ref={el => (this.multiGrid = el)}
           width={width}
-          columnWidth={this.getColumnWidthFunction()}
+          columnWidth={this.calculateColumnWidths}
           columnCount={Array.isArray(columns) ? columns.length : 0}
           fixedColumnCount={fixedColumnCount}
           enableFixedColumnScroll={fixedColumnCount > 0}
@@ -463,6 +481,7 @@ class MuiTable extends Component {
           classNameTopRightGrid={'topRightGrid'}
           classNameBottomLeftGrid={'bottomLeftGrid'}
           classNameBottomRightGrid={'bottomRightGrid'}
+          onScrollbarPresenceChange={this.captureScrollbarSize}
         />
 
         {pagination && (


### PR DESCRIPTION
This fixes an additional issue with horizontal scrollbars causing a vertical scrollbar to appear. The proposed solution adds height to the table to compensate for horizontal scrollbars when shown.