### PR TITLE
Fixed horizontal scrollbar pushing outside bottom of container

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@128technology/mui-virtualized-table",
-  "version": "3.0.0-5",
+  "version": "3.0.0-6",
   "description": "Material-UI table with windowing, row/column freezing, and more",
   "main": "dist/index.js",
   "types": "index.d.ts",

--- a/src/index.js
+++ b/src/index.js
@@ -444,7 +444,7 @@ class MuiTable extends Component {
     const paginationHeight =
       theme.mixins.toolbar.minHeight + FOOTER_BORDER_HEIGHT;
 
-    const scrollbarHeight = scrollbar.horizontal ? scrollbar.size : 0;
+    const scrollbarHeight = scrollbar.horizontal && maxHeight ? scrollbar.size : 0;
 
     const calculatedHeightWithFooter =
       calculatedHeight + (pagination ? paginationHeight : 0) + scrollbarHeight;


### PR DESCRIPTION
Fixed edge case issue where tables without a height or maxHeight property supplied inside a larger container would not take into account that the additional horizontal scrollbar height in the new table height calculation would push the scrollbar outside the bottom of the container.